### PR TITLE
Update mustache library to fix rendering of partials

### DIFF
--- a/template.go
+++ b/template.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/Unknwon/com"
-	"github.com/hoisie/mustache"
+	"github.com/cbroglie/mustache"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -72,7 +72,11 @@ func (t *template) Render(schemes []*scheme) error {
 
 	for _, scheme := range schemes {
 		fileName := filepath.Join(outputDir, "base16-"+scheme.Slug+t.Extension)
-		rendered := m.Render(scheme.mustacheContext())
+		rendered, err := m.Render(scheme.mustacheContext())
+		if err != nil {
+			return err
+		}
+
 		err = ioutil.WriteFile(fileName, []byte(rendered), 0777)
 		if err != nil {
 			return err


### PR DESCRIPTION
The [new cbroglie version of the library](https://github.com/cbroglie/mustache) is a maintained fork of the original hoisie authored version of the mustache lib. It has fixes for the correct indentation of partials in mustache, as well as additional error handling.

With the old library mustache partial indentation was rendered incorrectly. For example if the first snippet is a file `my-partial.mustache`:

```mustache
  indented text
```

```mustache
Unindented text
{{> my-partial }}
```

Would render:

```
Unindented text
indented text
```

Now it renders:

```
Unindented text
  indented text
```