### PR TITLE
Initial attempt to add base24 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ this builder supports.
 
 * `scheme-slug-underscored` - A version of the scheme slug where dashes have
   been replaced with underscores.
+
+### Base24 Support
+
+This builder has experimental support for [base24](https://github.com/Base24)
+schemes and templates.


### PR DESCRIPTION
I've been meaning to do this for a while, but never got around to it. This is *very* experimental (I haven't tested this directly), but it should work.

One thing that might be nice to do in the future is add more official support for base24 schemes as an "extended palate" and provide a way for templates to either use it or not, though I don't know exactly what that looks like yet. 

CC @FredHappyface