### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "schemes"]
 	path = schemes
-	url = https://github.com/base16-project/base16-schemes.git
+	url = https://github.com/tinted-theming/base16-schemes.git

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,9 +12,9 @@ builds:
 dockers:
 -
   image_templates:
-  - "ghcr.io/base16-project/base16-builder-go:{{ .Tag }}"
-  - "ghcr.io/base16-project/base16-builder-go:v{{ .Major }}.{{ .Minor }}"
-  - "ghcr.io/base16-project/base16-builder-go:latest"
+  - "ghcr.io/tinted-theming/base16-builder-go:{{ .Tag }}"
+  - "ghcr.io/tinted-theming/base16-builder-go:v{{ .Major }}.{{ .Minor }}"
+  - "ghcr.io/tinted-theming/base16-builder-go:latest"
   extra_files:
   - entrypoint.sh
 archives:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2016 Kaleb Elwert
+Copyright (c) 2022 [Tinted Theming](https://github.com/tinted-theming)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A simple builder for base16 templates and schemes.
 
 This currently implements version 0.10.0 of the
-[base16 spec](https://github.com/base16-project/base16).
+[base16 spec](https://github.com/tinted-theming/home).
 
 ## Building
 
@@ -15,7 +15,7 @@ repo needs to be cloned before building.
 The following command will clone the schemes directory
 
 ```
-$ git clone https://github.com/base16-project/base16-schemes.git schemes
+$ git clone https://github.com/tinted-theming/base16-schemes.git schemes
 ```
 
 Now that the repo is cloned, you can use `go build` to create a binary. You may

--- a/action.yml
+++ b/action.yml
@@ -6,4 +6,4 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/base16-project/base16-builder-go:v0.2.5'
+  image: 'docker://ghcr.io/tinted-theming/base16-builder-go:v0.2.5'

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/base16-project/base16-builder-go
+module github.com/tinted-theming/base16-builder-go
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func init() {
 func getSchemesFromGithub() (fs.FS, error) {
 	log.Info("Attempting to load schemes from GitHub")
 
-	r, err := http.Get("https://github.com/base16-project/base16-schemes/archive/refs/heads/main.tar.gz")
+	r, err := http.Get("https://github.com/tinted-theming/base16-schemes/archive/refs/heads/main.tar.gz")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.