### PR TITLE
Skip hidden files and dirs when loading schemes

### DIFF
--- a/scheme.go
+++ b/scheme.go
@@ -66,11 +66,20 @@ func loadSchemes(schemesFS fs.FS) ([]*ColorScheme, bool) {
 			return err
 		}
 
+		filename := d.Name()
+
+		if strings.HasPrefix(filename, ".") {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
 		if d.IsDir() {
 			return nil
 		}
 
-		filename := d.Name()
 		if !strings.HasSuffix(filename, ".yaml") {
 			return nil
 		}


### PR DESCRIPTION
This updates scheme loading to skip all hidden files and directories. This will make it easier in the future to add linting or other CI tooling to the schemes repo.